### PR TITLE
Fix parsing of image paths containing spaces

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -81,7 +81,7 @@ export async function convertImage(
  * @returns TFile object from image url (internal link)
  */
 export function getFileByName(imgURL: string): TFile | null {
-	const fileBaseName = getBasename(imgURL);
+	const fileBaseName = getBasename(decodeURIComponent(imgURL));
 	if (fileBaseName == null || fileBaseName == "") {
 		dbg("getFileByName() cannot get file basename");
 		return null;


### PR DESCRIPTION
Hi there,
I want to use this plugin since it is exactly what I need, but noticed it does not work when the image contains spaces. I'm not a web developer, but I think the URI should be decoded first.